### PR TITLE
Added method to create a clean gitlab project

### DIFF
--- a/src/com/capgemini/productionline/configuration/GitLab.groovy
+++ b/src/com/capgemini/productionline/configuration/GitLab.groovy
@@ -51,6 +51,12 @@ class GitLab implements Serializable {
     this.context.httpRequest consoleLogResponseBody: true, customHeaders: [[maskValue: true, name: 'PRIVATE-TOKEN', value: accesstoken]], httpMode: 'POST', url: "${gitlabHostUrl}/api/v4/projects?name="+projectname+'&path='+projectpath+'&namespace_id='+groupid+'&default_branch='+branchname+'&description='+java.net.URLEncoder.encode(projectdescription, "UTF-8")+'&import_url='+importurl+'&visibility='+visibility
   }
 
+  public createProject(String groupname, String projectname, String projectpath, String projectdescription, String branchname, String visibility) {
+    def groupid = getGroupId(groupname)
+    // create project in target group
+    this.context.httpRequest consoleLogResponseBody: true, customHeaders: [[maskValue: true, name: 'PRIVATE-TOKEN', value: accesstoken]], httpMode: 'POST', url: "${gitlabHostUrl}/api/v4/projects?name="+projectname+'&path='+projectpath+'&namespace_id='+groupid+'&default_branch='+branchname+'&description='+java.net.URLEncoder.encode(projectdescription, "UTF-8")+'&visibility='+visibility
+  }
+
   //Creates a new branch in a gitlab project
   public createBranch(String group, String project, String from, String branchname) {
     def projectid = getProjectId(groupname)


### PR DESCRIPTION
Small PR. I only added a new method to create a clean repository in gitlab. I only remove the parameter import in order to be able to create clean repositories without the necessity of clone another one.

Maybe if you use the previous createProject method and you pass a empty string to importurl it work in the same way, but with the new method the way is more clear.