### PR TITLE
addNodeJS_Version allways add an installation

### DIFF
--- a/src/com/capgemini/productionline/configuration/Jenkins.groovy
+++ b/src/com/capgemini/productionline/configuration/Jenkins.groovy
@@ -280,13 +280,18 @@ import org.jenkinsci.plugins.configfiles.maven.security.*
     def desc = inst.getDescriptor("jenkins.plugins.nodejs.tools.NodeJSInstallation")
 
     def installations = [];
+    def install = true
 
     // Iteration over already exiting installation, they will be added to the installation list
     for (i in desc.getInstallations()) {
     	installations.push(i)
+
+      if (i.name == installName) {
+        install = false
+      }
     }
 
-    if (!installations.contains(installName)) {
+    if (install) {
       try {
         def installer = new NodeJSInstaller(nodeJS_Version, npmPackages, npmPackagesRefreshHours)
         def installerProps = new InstallSourceProperty([installer])

--- a/src/com/capgemini/productionline/configuration/Jenkins.groovy
+++ b/src/com/capgemini/productionline/configuration/Jenkins.groovy
@@ -286,19 +286,22 @@ import org.jenkinsci.plugins.configfiles.maven.security.*
     	installations.push(i)
     }
 
-    try {
-    def installer = new NodeJSInstaller(nodeJS_Version, npmPackages, npmPackagesRefreshHours)
-    def installerProps = new InstallSourceProperty([installer])
-    def installation = new NodeJSInstallation(installName, home, [installerProps])
-    installations.push(installation)
+    if (!installations.contains(installName)) {
+      try {
+        def installer = new NodeJSInstaller(nodeJS_Version, npmPackages, npmPackagesRefreshHours)
+        def installerProps = new InstallSourceProperty([installer])
+        def installation = new NodeJSInstallation(installName, home, [installerProps])
+        installations.push(installation)
 
-    desc.setInstallations(installations.toArray(new NodeJSInstallation[0]))
+        desc.setInstallations(installations.toArray(new NodeJSInstallation[0]))
 
-    desc.save()
-    } catch(Exception ex) {
-         println("Installation error  ");
-         return false;
+        desc.save()
+      } catch(Exception ex) {
+        println("Installation error  ");
+        return false;
+      }
     }
+    
     return true
   }
 


### PR DESCRIPTION
In our templates, we always use the the method **addNodeJS_Version** in order to add a nodeJS installation. The problem is that every time you execute that function it will create a new installation. If you usually execute the templates, you will get lot of nodeJS installations with the same name.

This PR is to solve that bug.